### PR TITLE
Create unconstrained testing against HS4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ install:
 
 script:
   - julia --check-bounds=yes -E 'Pkg.test("CUTEst"; coverage=true)'
-
+  - julia --check-bounds=yes -E 'cd(Pkg.dir("CUTEst")); include("test/runtests_unc.jl")'
 after_success:
   - julia -e 'cd(Pkg.dir("CUTEst")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/test/hs4.jl
+++ b/test/hs4.jl
@@ -1,0 +1,7 @@
+# HS4 definitions for testing purposes
+nvar = 2
+ncon = 0
+f(x) = (x[1]+1)^3/3 + x[2]
+g(x) = [(x[1]+1)^2; 1]
+H(x) = [2*(x[1]+1) 0; 0 0]
+x0 = [1.125; 0.125]

--- a/test/runtests_unc.jl
+++ b/test/runtests_unc.jl
@@ -1,0 +1,5 @@
+problem = "HS4"
+include("hs4.jl")
+include("build_test.jl")
+include("test_julia.jl")
+include("finalize_test.jl")


### PR DESCRIPTION
HS4 is unconstrained, and the test code is the same.
Note that, currently, we can't call these two tests in the same julia instance, so the `Pkg.test` only runs with HS32, and then we create another julia instance to run `runtests_unc.jl`. This means no increase in coverage.