### PR TITLE
Core interface

### DIFF
--- a/interface_script/build_interface.py
+++ b/interface_script/build_interface.py
@@ -118,6 +118,8 @@ for name in functions:
         t = cutypes[vars[var]["type"]]
         types.append("Ptr{"+t+"}")
     core.write(el.join(textwrap.wrap(', '.join(types))))
+    if len(types) == 1:
+        core.write(",")
     core.write("),\n")
     ccall = []
     for var in funcall:

--- a/interface_script/build_interface.py
+++ b/interface_script/build_interface.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+import os
+import re
+import sys
+import textwrap
+
+# Type conversion
+cutypes = {"integer":"Cint", "doublereal":"Cdouble", "logical":"Cint",
+        "char":"Cchar", "real":"Cdouble"}
+jltypes = {"integer":"Integer", "doublereal":"Float64", "logical":"Bool",
+        "char":"Uint8", "real":"Float64"}
+
+# Workarounds
+ignore_intent = ["ureport", "creport"]
+
+cutest = os.getenv('CUTEST', "")
+if cutest is "":
+    print("ERROR: Variable CUTEST not set. Verify your CUTEst installation.")
+    exit(1)
+
+# The function definitions are being read from the C include file.
+# This should probably be improved to obtain more information about the
+# functions, but this is easier.
+functions = []
+with open(cutest+"/include/cutest.h") as file:
+    # Each new function starts with
+    # void CUTEST_xxx
+    for line in file:
+        if "void CUTEST" in line:
+            name = re.search('CUTEST_([a-z]*)', line).group(1).strip()
+            functions.append(name)
+
+s="  "
+el='\n'+2*s
+
+core = open("src/core_interface.jl","w")
+
+for name in functions:
+    vars = {}
+    funcall = []
+    with open(os.environ['CUTEST']+'/src/tools/'+name+'.f90','r') as f:
+        start_function = False
+        start_fundef = False
+        for line in f:
+            line = line.strip().lower()
+            if start_fundef:
+                for arg in re.search("(.*)[\)&]", line).group(1).split(','):
+                    if arg.strip() == "status":
+                        arg = "io_err"
+                    funcall.append(arg.strip())
+                if ")" in line:
+                    start_fundef = False
+            if "subroutine cutest_"+name+"(" in line:
+                start_function = True
+                start_fundef = True
+                for arg in re.search("\((.*)[&\)]", line).group(1).split(','):
+                    if arg.strip() == "status":
+                        arg = "io_err"
+                    funcall.append(arg.strip())
+                if ")" in line:
+                    start_fundef = False
+            if start_function:
+                for t in cutypes.keys():
+                    if t in line:
+                        intent = re.search("intent\( ([a-z]*) \)", line)
+                        if intent is None:
+                            if name in ignore_intent:
+                                intent = "out"
+                            else:
+                                continue
+                        else:
+                            intent = intent.group(1).strip()
+                        if intent == "inout":
+                            intent = "in"
+                        if "dimension" in line:
+                            is_ptr = True
+                            dim = re.search("dimension\(([ a-z_,:0-9]*)\)",
+                                    line).group(1).split(',')
+                        else:
+                            is_ptr = False
+                            dim = []
+                        args = re.search(":: (.*)", line).group(1).split(',')
+                        for arg in args:
+                            if arg.strip() == "status":
+                                arg = "io_err"
+                            if is_ptr:
+                                dims = []
+                                for d in dim:
+                                    if ":" in d:
+                                        a = d.split(':')[0]
+                                        b = d.split(':')[1]
+                                        d = "{} - {} + 1".format(b.strip(),a.strip())
+                                    else:
+                                        d = d.strip()
+                                    dims.append(d)
+                                dim = dims
+                            vars[arg.strip().lower()] = {"type":t, "intent":intent,
+                                    "ptr":is_ptr, "dim":dim}
+            if start_function and "end subroutine" in line:
+                break
+
+    funcall = [x for x in funcall if x]
+
+    args = []
+    for var in funcall:
+        t = cutypes[vars[var]["type"]]
+        d = max(len(vars[var]["dim"]),1)
+        args.append(var+"::Array{"+t+", "+str(d)+"}")
+    core.write("function "+name+"(")
+    core.write(el.join(textwrap.wrap(
+        ', '.join(args)+", libname = fixedlibname")))
+    core.write(")\n")
+    core.write(s+'@eval ccall(("cutest_'+name+'_", $(libname)), Void,\n')
+    core.write(2*s+"(")
+    types = []
+    for var in funcall:
+        t = cutypes[vars[var]["type"]]
+        types.append("Ptr{"+t+"}")
+    core.write(el.join(textwrap.wrap(', '.join(types))))
+    core.write("),\n")
+    ccall = []
+    for var in funcall:
+        ccall.append("$({})".format(var))
+    core.write(2*s+el.join(textwrap.wrap(', '.join(ccall))))
+    core.write(")\n")
+    core.write("end\n\n")
+
+core.close()

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -79,9 +79,7 @@ function CUTEstModel(name :: ASCIIString)
   nvar = Cint[0];
   ncon = Cint[0];
 
-  @eval ccall((:cutest_cdimen_, $(libname)), Void,
-               (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}),
-                $(io_err),  &funit,     $(nvar),    $(ncon));
+  CUTEst.cdimen(io_err, [funit], nvar, ncon, libname)
   @cutest_error
   nvar = nvar[1];
   ncon = ncon[1];
@@ -97,13 +95,10 @@ function CUTEstModel(name :: ASCIIString)
 
   if ncon > 0
     # Equality constraints first, linear constraints first, nonlinear variables first.
-    @eval ccall((:cutest_csetup_, $(libname)), Void,
-                (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}),
-                 $(io_err),  &funit,     &5,         &6,         &$(nvar),   &$(ncon),   $(x),         $(bl),        $(bu),        $(v),         $(cl),        $(cu),        $(equatn),  $(linear),  &1,         &1,         &1);
+    CUTEst.csetup(io_err, [funit], Cint[5], Cint[6], [nvar], [ncon], x, bl, bu, v, cl, cu,
+      equatn, linear, Cint[1], Cint[1], Cint[1], libname)
   else
-    @eval ccall((:cutest_usetup_, $(libname)), Void,
-                (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
-                 $(io_err),  &funit,     &5,         &6,         &$(nvar),   $(x),         $(bl),        $(bu));
+    CUTEst.usetup(io_err, [funit], Cint[5], Cint[6], [nvar], x, bl, bu, libname)
   end
   @cutest_error
 
@@ -116,11 +111,11 @@ function CUTEstModel(name :: ASCIIString)
   nnzj = Cint[0];
 
   if ncon > 0
-    @eval ccall((:cutest_cdimsh_, $(libname)), Void, (Ptr{Int32}, Ptr{Int32}), $(io_err), $(nnzh));
-    @eval ccall((:cutest_cdimsj_, $(libname)), Void, (Ptr{Int32}, Ptr{Int32}), $(io_err), $(nnzj))
+    CUTEst.cdimsh(io_err, nnzh, libname)
+    CUTEst.cdimsj(io_err, nnzj, libname)
     nnzj[1] -= nvar;  # nnzj also counts the nonzeros in the objective gradient.
   else
-    @eval ccall((:cutest_udimsh_, $(libname)), Void, (Ptr{Int32}, Ptr{Int32}), $(io_err), $(nnzh));
+    CUTEst.udimsh(io_err, nnzh, libname)
   end
   @cutest_error
 
@@ -152,7 +147,7 @@ function cutest_finalize(nlp :: CUTEstModel)
   cutest_instances == 0 && return;
   io_err = Cint[0];
   terminate = nlp.meta.ncon > 0 ? "cutest_cterminate_" : "cutest_uterminate_";
-  @eval ccall(($(terminate), $(nlp.libname)), Void, (Ptr{Int32},), $(io_err));
+  CUTEst.cterminate(io_err, nlp.libname)
   @cutest_error
   cutest_instances -= 1;
   return;

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -14,6 +14,7 @@ type CUTEstModel
   libname :: ASCIIString;
 end
 
+const fixedlibname = "libCUTEstJL.jl"
 const cutest_arch  = get(ENV, "MYARCH", "");
 const cutest_dir   = get(ENV, "CUTEST", "");
 const outsdif = "OUTSDIF.d";
@@ -47,6 +48,7 @@ macro cutest_error()  # Handle nonzero exit codes.
   :(io_err[1] > 0 && throw(CUTEstException(io_err[1])))
 end
 
+include("core_interface.jl")
 include("julia_interface.jl")
 
 # Decode problem and build shared library.

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -504,13 +504,13 @@ end
 
 function uterminate(io_err::Array{Cint, 1}, libname = fixedlibname)
   @eval ccall(("cutest_uterminate_", $(libname)), Void,
-    (Ptr{Cint}),
+    (Ptr{Cint},),
     $(io_err))
 end
 
 function cterminate(io_err::Array{Cint, 1}, libname = fixedlibname)
   @eval ccall(("cutest_cterminate_", $(libname)), Void,
-    (Ptr{Cint}),
+    (Ptr{Cint},),
     $(io_err))
 end
 

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -1,0 +1,516 @@
+function usetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
+    io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_usetup_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(input), $(out), $(io_buffer), $(n), $(x), $(x_l), $(x_u))
+end
+
+function csetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
+    io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1},
+    y::Array{Cdouble, 1}, c_l::Array{Cdouble, 1}, c_u::Array{Cdouble, 1},
+    equatn::Array{Cint, 1}, linear::Array{Cint, 1}, e_order::Array{Cint,
+    1}, l_order::Array{Cint, 1}, v_order::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_csetup_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(input), $(out), $(io_buffer), $(n), $(m), $(x), $(x_l),
+    $(x_u), $(y), $(c_l), $(c_u), $(equatn), $(linear), $(e_order),
+    $(l_order), $(v_order))
+end
+
+function udimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_udimen_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(input), $(n))
+end
+
+function udimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_udimsh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(nnzh))
+end
+
+function udimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
+    he_row_ne::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_udimse_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(ne), $(he_val_ne), $(he_row_ne))
+end
+
+function uvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_uvartype_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x_type))
+end
+
+function unames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, pname::Array{Cchar, 1},
+    vname::Array{Cchar, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_unames_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}),
+    $(io_err), $(n), $(pname), $(vname))
+end
+
+function ureport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
+    1}, libname = fixedlibname)
+  @eval ccall(("cutest_ureport_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(calls), $(time))
+end
+
+function cdimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
+    m::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_cdimen_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(input), $(n), $(m))
+end
+
+function cdimsj(io_err::Array{Cint, 1}, nnzj::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_cdimsj_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(nnzj))
+end
+
+function cdimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_cdimsh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(nnzh))
+end
+
+function cdimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
+    he_row_ne::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_cdimse_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(ne), $(he_val_ne), $(he_row_ne))
+end
+
+function cstats(io_err::Array{Cint, 1}, nonlinear_variables_objective::Array{Cint, 1},
+    nonlinear_variables_constraints::Array{Cint, 1},
+    equality_constraints::Array{Cint, 1}, linear_constraints::Array{Cint,
+    1}, libname = fixedlibname)
+  @eval ccall(("cutest_cstats_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(nonlinear_variables_objective),
+    $(nonlinear_variables_constraints), $(equality_constraints),
+    $(linear_constraints))
+end
+
+function cvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_cvartype_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x_type))
+end
+
+function cnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    pname::Array{Cchar, 1}, vname::Array{Cchar, 1}, cname::Array{Cchar,
+    1}, libname = fixedlibname)
+  @eval ccall(("cutest_cnames_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}),
+    $(io_err), $(n), $(m), $(pname), $(vname), $(cname))
+end
+
+function creport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
+    1}, libname = fixedlibname)
+  @eval ccall(("cutest_creport_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(calls), $(time))
+end
+
+function connames(io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{Cchar, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_connames_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
+    $(io_err), $(m), $(cname))
+end
+
+function pname(io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{Cchar, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_pname_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
+    $(io_err), $(input), $(pname))
+end
+
+function probname(io_err::Array{Cint, 1}, pname::Array{Cchar, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_probname_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cchar}),
+    $(io_err), $(pname))
+end
+
+function varnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{Cchar, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_varnames_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
+    $(io_err), $(n), $(vname))
+end
+
+function ufn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    f::Array{Cdouble, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ufn_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(n), $(x), $(f))
+end
+
+function ugr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    g::Array{Cdouble, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ugr_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(n), $(x), $(g))
+end
+
+function uofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_uofg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}),
+    $(io_err), $(n), $(x), $(f), $(g), $(grad))
+end
+
+function ubandh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    semibandwidth::Array{Cint, 1}, h_band::Array{Cdouble, 2},
+    lbandh::Array{Cint, 1}, max_semibandwidth::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_ubandh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(semibandwidth), $(h_band), $(lbandh),
+    $(max_semibandwidth))
+end
+
+function udh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    lh1::Array{Cint, 1}, h::Array{Cdouble, 2}, libname = fixedlibname)
+  @eval ccall(("cutest_udh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
+    $(io_err), $(n), $(x), $(lh1), $(h))
+end
+
+function ush(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    nnzh::Array{Cint, 1}, lh::Array{Cint, 1}, h_val::Array{Cdouble, 1},
+    h_row::Array{Cint, 1}, h_col::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ush_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(nnzh), $(lh), $(h_val), $(h_row), $(h_col))
+end
+
+function ueh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint,
+    1}, he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
+    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
+    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_ueh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(ne), $(lhe_ptr), $(he_row_ptr),
+    $(he_val_ptr), $(lhe_row), $(he_row), $(lhe_val), $(he_val), $(byrows))
+end
+
+function ugrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    g::Array{Cdouble, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2},
+    libname = fixedlibname)
+  @eval ccall(("cutest_ugrdh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
+    Ptr{Cdouble}),
+    $(io_err), $(n), $(x), $(g), $(lh1), $(h))
+end
+
+function ugrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    g::Array{Cdouble, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
+    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
+    1}, libname = fixedlibname)
+  @eval ccall(("cutest_ugrsh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(g), $(nnzh), $(lh), $(h_val), $(h_row),
+    $(h_col))
+end
+
+function ugreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    g::Array{Cdouble, 1}, ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1},
+    he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
+    lhe_row::Array{Cint, 1}, he_row::Array{Cint, 1}, lhe_val::Array{Cint,
+    1}, he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_ugreh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(g), $(ne), $(lhe_ptr), $(he_row_ptr),
+    $(he_val_ptr), $(lhe_row), $(he_row), $(lhe_val), $(he_val), $(byrows))
+end
+
+function uhprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
+    x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
+    result::Array{Cdouble, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_uhprod_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cdouble}),
+    $(io_err), $(n), $(goth), $(x), $(vector), $(result))
+end
+
+function cfn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, f::Array{Cdouble, 1}, c::Array{Cdouble, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_cfn_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cdouble}),
+    $(io_err), $(n), $(m), $(x), $(f), $(c))
+end
+
+function cofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_cofg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}),
+    $(io_err), $(n), $(x), $(f), $(g), $(grad))
+end
+
+function cofsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    f::Array{Cdouble, 1}, nnzg::Array{Cint, 1}, lg::Array{Cint, 1},
+    g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1}, grad::Array{Cint, 1},
+    libname = fixedlibname)
+  @eval ccall(("cutest_cofsg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(f), $(nnzg), $(lg), $(g_val), $(g_var),
+    $(grad))
+end
+
+function ccfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, jtrans::Array{Cint, 1},
+    lcjac1::Array{Cint, 1}, lcjac2::Array{Cint, 1}, cjac::Array{Cdouble,
+    2}, grad::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ccfg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(c), $(jtrans), $(lcjac1), $(lcjac2),
+    $(cjac), $(grad))
+end
+
+function clfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, f::Array{Cdouble, 1},
+    g::Array{Cdouble, 1}, grad::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_clfg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(f), $(g), $(grad))
+end
+
+function cgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
+    g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
+    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, libname = fixedlibname)
+  @eval ccall(("cutest_cgr_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+    $(io_err), $(n), $(m), $(x), $(y), $(grlagf), $(g), $(jtrans), $(lj1),
+    $(lj2), $(j_val))
+end
+
+function csgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
+    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
+    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_csgr_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(grlagf), $(nnzj), $(lj),
+    $(j_val), $(j_var), $(j_fun))
+end
+
+function ccfsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, nnzj::Array{Cint, 1},
+    lj::Array{Cint, 1}, j_val::Array{Cdouble, 1}, j_var::Array{Cint, 1},
+    j_fun::Array{Cint, 1}, grad::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ccfsg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(c), $(nnzj), $(lj), $(j_val), $(j_var),
+    $(j_fun), $(grad))
+end
+
+function ccifg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
+    x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, gci::Array{Cdouble, 1},
+    grad::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ccifg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(icon), $(x), $(ci), $(gci), $(grad))
+end
+
+function ccifsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
+    x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, nnzgci::Array{Cint, 1},
+    lgci::Array{Cint, 1}, gci_val::Array{Cdouble, 1}, gci_var::Array{Cint,
+    1}, grad::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_ccifsg_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(icon), $(x), $(ci), $(nnzgci), $(lgci), $(gci_val),
+    $(gci_var), $(grad))
+end
+
+function cgrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
+    g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
+    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, lh1::Array{Cint, 1},
+    h_val::Array{Cdouble, 2}, libname = fixedlibname)
+  @eval ccall(("cutest_cgrdh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
+    $(io_err), $(n), $(m), $(x), $(y), $(grlagf), $(g), $(jtrans), $(lj1),
+    $(lj2), $(j_val), $(lh1), $(h_val))
+end
+
+function cdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
+    h_val::Array{Cdouble, 2}, libname = fixedlibname)
+  @eval ccall(("cutest_cdh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cdouble}),
+    $(io_err), $(n), $(m), $(x), $(y), $(lh1), $(h_val))
+end
+
+function csh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
+    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
+    h_col::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_csh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(nnzh), $(lh), $(h_val), $(h_row),
+    $(h_col))
+end
+
+function cshc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
+    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
+    h_col::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_cshc_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(nnzh), $(lh), $(h_val), $(h_row),
+    $(h_col))
+end
+
+function ceh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, ne::Array{Cint, 1},
+    lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
+    he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
+    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
+    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_ceh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(ne), $(lhe_ptr), $(he_row_ptr),
+    $(he_val_ptr), $(lhe_row), $(he_row), $(lhe_val), $(he_val), $(byrows))
+end
+
+function cidh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    iprob::Array{Cint, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2},
+    libname = fixedlibname)
+  @eval ccall(("cutest_cidh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+    $(io_err), $(n), $(x), $(iprob), $(lh1), $(h))
+end
+
+function cish(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
+    iprob::Array{Cint, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
+    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
+    1}, libname = fixedlibname)
+  @eval ccall(("cutest_cish_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(x), $(iprob), $(nnzh), $(lh), $(h_val), $(h_row),
+    $(h_col))
+end
+
+function csgrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
+    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
+    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, nnzh::Array{Cint, 1},
+    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
+    h_col::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_csgrsh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(grlagf), $(nnzj), $(lj),
+    $(j_val), $(j_var), $(j_fun), $(nnzh), $(lh), $(h_val), $(h_row),
+    $(h_col))
+end
+
+function csgreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
+    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
+    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, ne::Array{Cint, 1},
+    lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
+    he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
+    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
+    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_csgreh_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
+    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(x), $(y), $(grlagf), $(nnzj), $(lj),
+    $(j_val), $(j_var), $(j_fun), $(ne), $(lhe_ptr), $(he_row_ptr),
+    $(he_val_ptr), $(lhe_row), $(he_row), $(lhe_val), $(he_val), $(byrows))
+end
+
+function chprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
+    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_chprod_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(n), $(m), $(goth), $(x), $(y), $(vector), $(result))
+end
+
+function chcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
+    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_chcprod_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+    $(io_err), $(n), $(m), $(goth), $(x), $(y), $(vector), $(result))
+end
+
+function cjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
+    gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
+    vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
+    result::Array{Cdouble, 1}, lresult::Array{Cint, 1}, libname =
+    fixedlibname)
+  @eval ccall(("cutest_cjprod_", $(libname)), Void,
+    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
+    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
+    $(io_err), $(n), $(m), $(gotj), $(jtrans), $(x), $(vector),
+    $(lvector), $(result), $(lresult))
+end
+
+function uterminate(io_err::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_uterminate_", $(libname)), Void,
+    (Ptr{Cint}),
+    $(io_err))
+end
+
+function cterminate(io_err::Array{Cint, 1}, libname = fixedlibname)
+  @eval ccall(("cutest_cterminate_", $(libname)), Void,
+    (Ptr{Cint}),
+    $(io_err))
+end
+

--- a/test/build_test.jl
+++ b/test/build_test.jl
@@ -8,5 +8,6 @@ cd(tmpdir);
 
 nlp = CUTEstModel(problem);
 x0 = nlp.meta.x0
+y0 = ones(nlp.meta.ncon) # To guarantee that y0 is not zero
 
 print(nlp);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 problem = "HS32"
 include("hs32.jl")
 include("build_test.jl")
+include("test_core.jl")
 include("test_julia.jl")
 include("finalize_test.jl")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -3,8 +3,10 @@ st = Cint[0]
 nvar = Cint[nlp.meta.nvar]
 ncon = Cint[nlp.meta.ncon]
 fx = [0.0]
+lx = [0.0]
 cx = Array(Cdouble, ncon[1])
 gx = Array(Cdouble, nvar[1])
+glx = Array(Cdouble, nvar[1])
 gval = Array(Cdouble, nvar[1])
 gvar = Array(Cint, nvar[1])
 nnzg = Cint[0]
@@ -33,6 +35,10 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Jtx J(x0)' 1e-8
   CUTEst.ccfg(st, nvar, ncon, x0, cx, Cint[false], ncon, nvar, Jx, grad, nlp.libname)
   @test_approx_eq_eps Jx J(x0) 1e-8
+
+  CUTEst.clfg(st, nvar, ncon, x0, y0, lx, glx, grad, nlp.libname)
+  @test_approx_eq_eps lx f(x0)+dot(y0,cx) 1e-8
+  @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -252,6 +252,17 @@ if (ncon[1] > 0)
   Hv = Array(Cdouble, nvar[1])
   CUTEst.chcprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.libname)
   @test_approx_eq_eps Hv (W(x0,y0)-H(x0))*v 1e-8
+
+  v = ones(nvar[1])
+  Jv = Array(Cdouble, ncon[1])
+  CUTEst.cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon,
+      nlp.libname)
+  @test_approx_eq_eps Jv J(x0)*v 1e-8
+  v = ones(ncon[1])
+  Jtv = Array(Cdouble, nvar[1])
+  CUTEst.cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar,
+      nlp.libname)
+  @test_approx_eq_eps Jtv J(x0)'*v 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -248,6 +248,10 @@ if (ncon[1] > 0)
   Hv = Array(Cdouble, nvar[1])
   CUTEst.chprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.libname)
   @test_approx_eq_eps Hv W(x0,y0)*v 1e-8
+
+  Hv = Array(Cdouble, nvar[1])
+  CUTEst.chcprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.libname)
+  @test_approx_eq_eps Hv (W(x0,y0)-H(x0))*v 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -180,6 +180,28 @@ if (ncon[1] > 0)
     @test_approx_eq_eps Cx (W(x0,y1)-H(x0)) 1e-8
     y1[k] = 0.0
   end
+
+  CUTEst.cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol, nlp.libname)
+  Hx = zeros(nvar[1], nvar[1])
+  for k = 1:nnzh[1]
+    i = Hrow[k]; j = Hcol[k];
+    Hx[i,j] = Hval[k]
+    i != j && (Hx[j,i] = Hval[k])
+  end
+  @test_approx_eq_eps Hx H(x0) 1e-8
+  y1 = zeros(ncon[1])
+  for k = 1:ncon[1]
+    CUTEst.cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol, nlp.libname)
+    Cx = zeros(nvar[1], nvar[1])
+    for k2 = 1:nnzh[1]
+      i = Hrow[k2]; j = Hcol[k2];
+      Cx[i,j] = Hval[k2]
+      i != j && (Cx[j,i] = Hval[k2])
+    end
+    y1[k] = 1.0
+    @test_approx_eq_eps Cx (W(x0,y1)-H(x0)) 1e-8
+    y1[k] = 0.0
+  end
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -23,7 +23,7 @@ Jtx = Array(Cdouble, nvar[1],ncon[1])
 Jval = Array(Cdouble, nlp.meta.nnzj+nlp.meta.nvar)
 Jvar = Array(Cint, nlp.meta.nnzj+nlp.meta.nvar)
 Jfun = Array(Cint, nlp.meta.nnzj+nlp.meta.nvar)
-Hx = Array(Cdouble, nvar[1],nvar[1])
+Hx = Array(Cdouble, nvar[1], nvar[1])
 Hval = Array(Cdouble, nlp.meta.nnzh)
 Hrow = Array(Cint, nlp.meta.nnzh)
 Hcol = Array(Cint, nlp.meta.nnzh)
@@ -159,6 +159,15 @@ if (ncon[1] > 0)
     i != j && (Hx[j,i] = Hval[k])
   end
   @test_approx_eq_eps Hx W(x0,y0) 1e-8
+
+  CUTEst.cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol, nlp.libname)
+  Cx = zeros(nvar[1], nvar[1])
+  for k = 1:nnzh[1]
+    i = Hrow[k]; j = Hcol[k];
+    Cx[i,j] = Hval[k]
+    i != j && (Cx[j,i] = Hval[k])
+  end
+  @test_approx_eq_eps Cx (W(x0,y0)-H(x0)) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -108,6 +108,18 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
+
+  Jx = zeros(ncon[1], nvar[1])
+  for j = 1:ncon[1]
+    CUTEst.ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True,
+        nlp.libname)
+    cx[j] = ci[1]
+    for k = 1:nnzj[1]
+      Jx[j,Jvar[k]] = Jval[k]
+    end
+  end
+  @test_approx_eq_eps cx c(x0) 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -243,6 +243,11 @@ if (ncon[1] > 0)
   @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
+
+  v = ones(nvar[1])
+  Hv = Array(Cdouble, nvar[1])
+  CUTEst.chprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.libname)
+  @test_approx_eq_eps Hv W(x0,y0)*v 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -75,16 +75,16 @@ if (ncon[1] > 0)
 
   CUTEst.csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun,
       nlp.libname)
-  gx = zeros(nvar[1])
+  glx = zeros(nvar[1])
   Jx = zeros(nvar[1], ncon[1])
   for k = 1:nnzj[1]
     if Jfun[k] == 0
-      gx[Jvar[k]] = Jval[k]
+      glx[Jvar[k]] = Jval[k]
     else
       Jtx[Jvar[k],Jfun[k]] = Jval[k]
     end
   end
-  @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
+  @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
   CUTEst.csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun,
       nlp.libname)
@@ -202,6 +202,47 @@ if (ncon[1] > 0)
     @test_approx_eq_eps Cx (W(x0,y1)-H(x0)) 1e-8
     y1[k] = 0.0
   end
+
+  CUTEst.csgrsh(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
+      lh, Hval, Hrow, Hcol, nlp.libname)
+  gx = zeros(nvar[1])
+  Jx = zeros(ncon[1], nvar[1])
+  for k = 1:nnzj[1]
+    if Jfun[k] == 0
+      gx[Jvar[k]] = Jval[k]
+    else
+      Jx[Jfun[k],Jvar[k]] = Jval[k]
+    end
+  end
+  Wx = zeros(nvar[1], nvar[1])
+  for k = 1:nnzh[1]
+    i = Hrow[k]; j = Hcol[k];
+    Wx[i,j] = Hval[k]
+    i != j && (Wx[j,i] = Hval[k])
+  end
+  @test_approx_eq_eps gx g(x0) 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+  @test_approx_eq_eps Wx W(x0,y0) 1e-8
+  CUTEst.csgrsh(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
+      lh, Hval, Hrow, Hcol, nlp.libname)
+  glx = zeros(nvar[1])
+  Jx = zeros(ncon[1], nvar[1])
+  for k = 1:nnzj[1]
+    if Jfun[k] == 0
+      glx[Jvar[k]] = Jval[k]
+    else
+      Jx[Jfun[k],Jvar[k]] = Jval[k]
+    end
+  end
+  Wx = zeros(nvar[1], nvar[1])
+  for k = 1:nnzh[1]
+    i = Hrow[k]; j = Hcol[k];
+    Wx[i,j] = Hval[k]
+    i != j && (Wx[j,i] = Hval[k])
+  end
+  @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+  @test_approx_eq_eps Wx W(x0,y0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -21,6 +21,7 @@ Jtx = Array(Cdouble, nvar[1],ncon[1])
 Jval = Array(Cdouble, nlp.meta.nnzj+nlp.meta.nvar)
 Jvar = Array(Cint, nlp.meta.nnzj+nlp.meta.nvar)
 Jfun = Array(Cint, nlp.meta.nnzj+nlp.meta.nvar)
+Hx = Array(Cdouble, nvar[1],nvar[1])
 
 if (ncon[1] > 0)
   CUTEst.cfn(st, nvar, ncon, x0, fx, cx, nlp.libname)
@@ -120,6 +121,27 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
+
+  CUTEst.cgrdh(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
+      Hx, nlp.libname)
+  @test_approx_eq_eps gx g(x0) 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+  @test_approx_eq_eps Hx W(x0,y0) 1e-8
+  CUTEst.cgrdh(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
+      Hx, nlp.libname)
+  @test_approx_eq_eps gx g(x0) 1e-8
+  @test_approx_eq_eps Jtx J(x0)' 1e-8
+  @test_approx_eq_eps Hx W(x0,y0) 1e-8
+  CUTEst.cgrdh(st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
+      Hx, nlp.libname)
+  @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+  @test_approx_eq_eps Hx W(x0,y0) 1e-8
+  CUTEst.cgrdh(st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
+      Hx, nlp.libname)
+  @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
+  @test_approx_eq_eps Jtx J(x0)' 1e-8
+  @test_approx_eq_eps Hx W(x0,y0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
@@ -135,3 +157,4 @@ if (ncon[1] > 0)
   println("c(x0) = ", cx)
   println("J(x0) = "); println(Jx)
 end
+println("H(x0,y0) = "); println(Hx)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -10,7 +10,8 @@ glx = Array(Cdouble, nvar[1])
 gval = Array(Cdouble, nvar[1])
 gvar = Array(Cint, nvar[1])
 nnzg = Cint[0]
-grad = Cint[true]
+True = Cint[true]
+False = Cint[false]
 Jx = Array(Cdouble, ncon[1],nvar[1])
 Jtx = Array(Cdouble, nvar[1],ncon[1])
 
@@ -19,11 +20,11 @@ if (ncon[1] > 0)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   @test_approx_eq_eps cx c(x0) 1e-8
 
-  CUTEst.cofg(st, nvar, x0, fx, gx, grad, nlp.libname)
+  CUTEst.cofg(st, nvar, x0, fx, gx, True, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  CUTEst.cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, grad, nlp.libname)
+  CUTEst.cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   gx = zeros(nvar[1])
   for i = 1:nnzg[1]
@@ -31,14 +32,31 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  CUTEst.ccfg(st, nvar, ncon, x0, cx, Cint[true], nvar, ncon, Jtx, grad, nlp.libname)
+  CUTEst.ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True, nlp.libname)
   @test_approx_eq_eps Jtx J(x0)' 1e-8
-  CUTEst.ccfg(st, nvar, ncon, x0, cx, Cint[false], ncon, nvar, Jx, grad, nlp.libname)
+  CUTEst.ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True, nlp.libname)
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  CUTEst.clfg(st, nvar, ncon, x0, y0, lx, glx, grad, nlp.libname)
-  @test_approx_eq_eps lx f(x0)+dot(y0,cx) 1e-8
+  CUTEst.clfg(st, nvar, ncon, x0, y0, lx, glx, True, nlp.libname)
+  @test_approx_eq_eps lx[1] f(x0)+dot(y0,cx) 1e-8
   @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
+
+  CUTEst.cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx,
+      nlp.libname)
+  @test_approx_eq_eps gx g(x0) 1e-8
+  @test_approx_eq_eps Jtx J(x0)' 1e-8
+  CUTEst.cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx,
+      nlp.libname)
+  @test_approx_eq_eps gx g(x0) 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+  CUTEst.cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx,
+      nlp.libname)
+  @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
+  @test_approx_eq_eps Jtx J(x0)' 1e-8
+  CUTEst.cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx,
+      nlp.libname)
+  @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1,0 +1,50 @@
+println("\nTesting the core interface\n")
+st = Cint[0]
+nvar = Cint[nlp.meta.nvar]
+ncon = Cint[nlp.meta.ncon]
+fx = [0.0]
+cx = Array(Cdouble, ncon[1])
+gx = Array(Cdouble, nvar[1])
+gval = Array(Cdouble, nvar[1])
+gvar = Array(Cint, nvar[1])
+nnzg = Cint[0]
+grad = Cint[true]
+Jx = Array(Cdouble, ncon[1],nvar[1])
+Jtx = Array(Cdouble, nvar[1],ncon[1])
+
+if (ncon[1] > 0)
+  CUTEst.cfn(st, nvar, ncon, x0, fx, cx, nlp.libname)
+  @test_approx_eq_eps fx[1] f(x0) 1e-8
+  @test_approx_eq_eps cx c(x0) 1e-8
+
+  CUTEst.cofg(st, nvar, x0, fx, gx, grad, nlp.libname)
+  @test_approx_eq_eps fx[1] f(x0) 1e-8
+  @test_approx_eq_eps gx g(x0) 1e-8
+
+  CUTEst.cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, grad, nlp.libname)
+  @test_approx_eq_eps fx[1] f(x0) 1e-8
+  gx = zeros(nvar[1])
+  for i = 1:nnzg[1]
+    gx[gvar[i]] = gval[i]
+  end
+  @test_approx_eq_eps gx g(x0) 1e-8
+
+  CUTEst.ccfg(st, nvar, ncon, x0, cx, Cint[true], nvar, ncon, Jtx, grad, nlp.libname)
+  @test_approx_eq_eps Jtx J(x0)' 1e-8
+  CUTEst.ccfg(st, nvar, ncon, x0, cx, Cint[false], ncon, nvar, Jx, grad, nlp.libname)
+  @test_approx_eq_eps Jx J(x0) 1e-8
+else
+  CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
+  @test_approx_eq_eps fx[1] f(x0) 1e-8
+
+  CUTEst.uofg(st, nvar, x0, fx, gx, grad, nlp.libname)
+  @test_approx_eq_eps fx[1] f(x0) 1e-8
+  @test_approx_eq_eps gx g(x0) 1e-8
+end
+
+println("f(x0) = ", fx[1])
+println("∇f(x0) = ", gx)
+if (ncon[1] > 0)
+  println("c(x0) = ", cx)
+  println("J(x0) = "); println(Jx)
+end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -142,6 +142,9 @@ if (ncon[1] > 0)
   @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
   @test_approx_eq_eps Hx W(x0,y0) 1e-8
+
+  CUTEst.cdh(st, nvar, ncon, x0, y0, nvar, Hx, nlp.libname)
+  @test_approx_eq_eps Hx W(x0,y0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)
   @test_approx_eq_eps fx[1] f(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -12,8 +12,10 @@ glx = Array(Cdouble, nvar[1])
 gval = Array(Cdouble, nvar[1])
 gvar = Array(Cint, nvar[1])
 lj = Cint[nlp.meta.nnzj+nlp.meta.nvar]
+lh = Cint[nlp.meta.nnzh]
 nnzg = Cint[0]
 nnzj = Cint[0]
+nnzh = Cint[0]
 True = Cint[true]
 False = Cint[false]
 Jx = Array(Cdouble, ncon[1],nvar[1])
@@ -22,6 +24,9 @@ Jval = Array(Cdouble, nlp.meta.nnzj+nlp.meta.nvar)
 Jvar = Array(Cint, nlp.meta.nnzj+nlp.meta.nvar)
 Jfun = Array(Cint, nlp.meta.nnzj+nlp.meta.nvar)
 Hx = Array(Cdouble, nvar[1],nvar[1])
+Hval = Array(Cdouble, nlp.meta.nnzh)
+Hrow = Array(Cint, nlp.meta.nnzh)
+Hcol = Array(Cint, nlp.meta.nnzh)
 
 if (ncon[1] > 0)
   CUTEst.cfn(st, nvar, ncon, x0, fx, cx, nlp.libname)
@@ -144,6 +149,15 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Hx W(x0,y0) 1e-8
 
   CUTEst.cdh(st, nvar, ncon, x0, y0, nvar, Hx, nlp.libname)
+  @test_approx_eq_eps Hx W(x0,y0) 1e-8
+
+  CUTEst.csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol, nlp.libname)
+  Hx = zeros(nvar[1], nvar[1])
+  for k = 1:nnzh[1]
+    i = Hrow[k]; j = Hcol[k];
+    Hx[i,j] = Hval[k]
+    i != j && (Hx[j,i] = Hval[k])
+  end
   @test_approx_eq_eps Hx W(x0,y0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -4,8 +4,10 @@ nvar = Cint[nlp.meta.nvar]
 ncon = Cint[nlp.meta.ncon]
 fx = [0.0]
 lx = [0.0]
+ci = [0.0]
 cx = Array(Cdouble, ncon[1])
 gx = Array(Cdouble, nvar[1])
+gci = Array(Cdouble, nvar[1])
 glx = Array(Cdouble, nvar[1])
 gval = Array(Cdouble, nvar[1])
 gvar = Array(Cint, nvar[1])
@@ -95,6 +97,14 @@ if (ncon[1] > 0)
   Jx = zeros(ncon[1], nvar[1])
   for k = 1:nnzj[1]
     Jx[Jfun[k],Jvar[k]] = Jval[k]
+  end
+  @test_approx_eq_eps cx c(x0) 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+
+  for j = 1:ncon[1]
+    CUTEst.ccifg(st, nvar, Cint[j], x0, ci, gci, True, nlp.libname)
+    cx[j] = ci[1]
+    Jx[j,:] = gci'
   end
   @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -65,8 +65,8 @@ if (ncon[1] > 0)
 
   CUTEst.csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun,
       nlp.libname)
-  gx = zeros(nlp.meta.nvar)
-  Jx = zeros(nlp.meta.nvar, nlp.meta.ncon)
+  gx = zeros(nvar[1])
+  Jx = zeros(nvar[1], ncon[1])
   for k = 1:nnzj[1]
     if Jfun[k] == 0
       gx[Jvar[k]] = Jval[k]
@@ -78,8 +78,8 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Jtx J(x0)' 1e-8
   CUTEst.csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun,
       nlp.libname)
-  gx = zeros(nlp.meta.nvar)
-  Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
+  gx = zeros(nvar[1])
+  Jx = zeros(ncon[1], nvar[1])
   for k = 1:nnzj[1]
     if Jfun[k] == 0
       gx[Jvar[k]] = Jval[k]
@@ -88,6 +88,15 @@ if (ncon[1] > 0)
     end
   end
   @test_approx_eq_eps gx g(x0) 1e-8
+  @test_approx_eq_eps Jx J(x0) 1e-8
+
+  CUTEst.ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True,
+      nlp.libname)
+  Jx = zeros(ncon[1], nvar[1])
+  for k = 1:nnzj[1]
+    Jx[Jfun[k],Jvar[k]] = Jval[k]
+  end
+  @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 else
   CUTEst.ufn(st, nvar, x0, fx, nlp.libname)

--- a/test/test_julia.jl
+++ b/test/test_julia.jl
@@ -1,3 +1,4 @@
+println("\nTesting the Julia interface\n")
 fx = obj(nlp, x0);
 @test_approx_eq_eps fx f(x0) 1e-8
 


### PR DESCRIPTION
This bundle contains
- The script to generate, and the generated, core interface
- Tests for a large part of the core interface
- Change in `CUTEst.jl` to use the core interface instead of the `ccall`.

Some constrained functions were not tested, specially the finite element related.
Most unconstrained functions were not tested, as they were not going to improve coverage.