### PR TITLE
Fix type warnings and & in objcons ccall

### DIFF
--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -20,7 +20,7 @@ const cutest_arch  = get(ENV, "MYARCH", "");
 const cutest_dir   = get(ENV, "CUTEST", "");
 const outsdif = "OUTSDIF.d";
 const automat = "AUTOMAT.d";
-const funit   = int32(42);
+const funit   = convert(Int32, 42);
 @osx? (const linker = "gfortran") : (const linker = "ld")
 @osx? (const sh_flags = ["-dynamiclib", "-undefined", "dynamic_lookup"]) : (const sh_flags = ["-shared"]);
 @osx? (const soname = "dylib") : (const soname = "so");
@@ -43,7 +43,7 @@ type CUTEstException <: Exception
   end
 end
 
-CUTEstException(info :: Integer) = CUTEstException(int32(info));
+CUTEstException(info :: Integer) = CUTEstException(convert(Int32, info));
 
 macro cutest_error()  # Handle nonzero exit codes.
   :(io_err[1] > 0 && throw(CUTEstException(io_err[1])))

--- a/src/julia_interface.jl
+++ b/src/julia_interface.jl
@@ -9,7 +9,7 @@ function objcons(nlp :: CUTEstModel, x :: Array{Float64,1})
   if ncon > 0
     @eval ccall((:cutest_cfn_, $(nlp.libname)), Void,
                 (Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
-                 $(io_err),  $(nvar),    $(ncon),    $(x),         $(f),         $(c));
+                 $(io_err),  &$(nvar),   &$(ncon),   $(x),         $(f),         $(c));
   else
     @eval ccall((:cutest_ufn_, $(nlp.libname)), Void,
                 (Ptr{Int32}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}),


### PR DESCRIPTION
Remove some warnings, and fix a `ccall`.